### PR TITLE
update moment-timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "moment-timezone": "0.2.4"
+    "moment-timezone": "~0.3.0"
   },
   "devDependencies": {
     "nodeunit": ">=0.5.4"


### PR DESCRIPTION
get rid of deprecation warning "Deprecation warning: moment().zone is deprecated, use moment().utcOffset instead. https://github.com/moment/moment/issues/1779"