### PR TITLE
Fixes the deprecation notice from moment.

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -97,7 +97,7 @@ CronTime.prototype = {
 	sendAt: function() {
 		var date = this.realDate ? this.source : moment();
 		if (this.zone)
-			date = date.tz(this.zone);
+			date = date.utcOffset(this.zone);
 
 		if (this.realDate)
 			return date;


### PR DESCRIPTION
`cron` was using `.tz` which was recently deprecated in https://github.com/moment/moment/issues/1779. This PR fixes the deprecation notice that `moment` was throwing.