### PR TITLE
Fix the timezone issue from 1.0.7

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -96,8 +96,9 @@ CronTime.prototype = {
 	 */
 	sendAt: function() {
 		var date = this.realDate ? this.source : moment();
+		// Set the timezone if given (http://momentjs.com/timezone/docs/#/using-timezones/parsing-in-zone/)
 		if (this.zone)
-			date = date.utcOffset(this.zone);
+			date = date.tz(this.zone);
 
 		if (this.realDate)
 			return date;


### PR DESCRIPTION
Hi!

Thank you for this awesome module.
I'm using it everyday with the timezone set (Europe/Paris), and today, all of my crons have 1 hour late.
I did some tests to see if the timezone is still working:
```javascript
var cronJob = require('cron').CronJob;
new cronJob({
	cronTime: '*/5 * 14 * * *', // every 5 seconds at 14h (it is 14h in France actually)
	timeZone: 'Europe/Paris',
	onTick: function () {
		console.log(new Date);
	},
	start: true
});
```
-> No console.log displayed.
I tried on my computer (french date) with and without the timeZone set, and that how I found what line to change in the code based on the moment Timezone documentation.

I'm using my fork actually on my project, but I would like to use your as soon as possible.
If you're ok to merge, can you please bump the version?

Thank you @ncb000gt :)
