### PR TITLE
Modified CronJob.prototype.setTime to throw error instance

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -374,7 +374,7 @@ var addCallback = function(callback) {
 CronJob.prototype.addCallback = addCallback;
 
 CronJob.prototype.setTime = function(time) {
-	if (!(time instanceof CronTime)) throw '\'time\' must be an instance of CronTime.';
+	if (!(time instanceof CronTime)) throw new Error('\'time\' must be an instance of CronTime.');
 	this.stop();
 	this.cronTime = time;
 }

--- a/tests/test-cron.js
+++ b/tests/test-cron.js
@@ -327,7 +327,7 @@ module.exports = testCase({
 		job.stop();
 		assert.throws(function() {
 			job.setTime(time);
-		});
+		}, Error, '\'time\' must be an instance of CronTime.');
 
 		clock.restore();
 		job.stop();


### PR DESCRIPTION
Before this commits, CronJob.prototype.setTime throw not error instance but string instance. so thrown error stack is `undefined`.
Show an example below.
```
$ cat hoge.js                                                                                                                                                 
var CronJob = require("./lib/cron").CronJob;
var job = new CronJob("* * * * *");

try {
  job.setTime(new Date());
} catch (err) {
  console.log(err.stack);
}
$ node hoge.js 
undefined
```

Modified setTIme to throw error instance.