### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,7 @@
     "nodeunit": ">=0.5.4",
     "sinon": "~1.12.x"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php" 
-    }
-  ],
+  "license": "MIT",
   "contributors": [
     "Romain Beauxis <toots@rastageeks.org> (https://github.com/toots)",
     "James Padolsey <> (https://github.com/jamespadolsey)",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/