### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
     "name": "cronjs",
-    "version": "1.0.1",
     "homepage": "https://github.com/ncb000gt/node-cron",
     "authors": [
         "Romain Beauxis<toots@rastageeks.org>",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property