### PR TITLE
Note discrepancy between cron formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Available Cron patterns:
     Ranges. E.g. 1-3,5
     Steps. E.g. */2
 
-[Read up on cron patterns here](http://crontab.org).
+[Read up on cron patterns here](http://crontab.org). Note the examples in the
+link have five fields, and 1 minute as the finest granularity, but this library
+has six fields, with 1 second as the finest granularity.
 
 Cron Ranges
 ==========
@@ -142,7 +144,7 @@ Install
 API
 ==========
 
-Parameter Based 
+Parameter Based
 
 `CronJob`
 


### PR DESCRIPTION
The README links to crontab.org, which provides examples with 5 fields and
minute granularity. node-cron expects the leftmost value to describe the
granularity in seconds. This inconsistency led me to misinterpret the running
times in a cron.CronJob.