### PR TITLE
Add a nextDates method to be able to easily get the next i occurences of a cronjob.

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -94,7 +94,7 @@ CronTime.prototype = {
 	/**
 	 * calculates the next send time
 	 */
-	sendAt: function() {
+	sendAt: function(i) {
 		var date = this.realDate ? this.source : moment();
 		// Set the timezone if given (http://momentjs.com/timezone/docs/#/using-timezones/parsing-in-zone/)
 		if (this.zone)
@@ -113,10 +113,22 @@ CronTime.prototype = {
 			//console.log('add 1 second?');
 			date = date.add(1, 's');
 		}
-
-		date = this._getNextDateFrom(date);
-
-		return date;
+		
+		//If the i argument is not given, return the next send time
+		if(isNaN(i) || i < 0){
+			date = this._getNextDateFrom(date);
+			return date;
+		}
+		//Else return the next i send times
+		else{
+			var dates = [];
+			for(;i>0;i--){
+				date = this._getNextDateFrom(date);
+				dates.push(date);
+				if(i>1) date.add(1,'s');
+			}
+			return dates;
+		}
 	},
 
 	/**
@@ -382,6 +394,10 @@ CronJob.prototype.setTime = function(time) {
 
 CronJob.prototype.nextDate = function() {
 	return this.cronTime.sendAt();
+}
+
+CronJob.prototype.nextDates = function(i) {
+	return this.cronTime.sendAt(i);	
 }
 
 var start = function() {

--- a/lib/cron.js
+++ b/lib/cron.js
@@ -124,7 +124,7 @@ CronTime.prototype = {
 			var dates = [];
 			for(;i>0;i--){
 				date = this._getNextDateFrom(date);
-				dates.push(date);
+				dates.push(moment(date));
 				if(i>1) date.add(1,'s');
 			}
 			return dates;


### PR DESCRIPTION
when using node-cron as a base for an agenda, it is useful to be able to easily calculate the next i occurences of a cron-job for displaying purposes etc.

the nextDates takes a positive integer i and returns an array containing the next i dates for the cron job.