### PR TITLE
Syntax highlight fix for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ As goes with semver, breaking backwards compatibility should be explicit in the 
 Usage (basic cron usage):
 ==========
 
-```javascript
+```js
 var CronJob = require('cron').CronJob;
 new CronJob('* * * * * *', function() {
   console.log('You will see this message every second');
@@ -66,7 +66,7 @@ When specifying your cron values you'll need to make sure that your values fall 
 Another cron example
 ==========
 
-```javascript
+```js
 var CronJob = require('cron').CronJob;
 var job = new CronJob('00 30 11 * * 1-5', function() {
   /*
@@ -85,7 +85,7 @@ var job = new CronJob('00 30 11 * * 1-5', function() {
 Another example with Date
 ==========
 
-```javascript
+```js
 var CronJob = require('cron').CronJob;
 var job = new CronJob(new Date(), function() {
   /* runs once at the specified date. */
@@ -100,7 +100,7 @@ var job = new CronJob(new Date(), function() {
 For good measure
 ==========
 
-```javascript
+```js
 var CronJob = require('cron').CronJob;
 var job = new CronJob({
   cronTime: '00 30 11 * * 1-5',
@@ -121,7 +121,7 @@ job.start();
 How to check if a cron pattern is valid:
 ==========
 
-```javascript
+```js
 try {
 	new CronJob('invalid cron pattern', function() {
 		console.log('this should not be printed');


### PR DESCRIPTION
Replaced "javascript" with "js". By this npm should be able to parse code snippets properly. Currently, it's a plain text. See here:
https://www.npmjs.com/package/cron